### PR TITLE
fix seen-blocks cache populating 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 * Merger now deletes one-block-files that it has seen before exactly like the ones that are passed MaxFixableFork, based on DeleteBlocksBefore
+* 'Live' option now changed to 'BatchMode' with the inverse behavior (for consistency with our other projects)
+* 'SeenBlocksFile' option changed to 'StateFile' since it now contains highestSeenBlock, used to determine next start block.
+* When merger is started, in live mode, it tries to get its start block from the state file. If it cannot, it locates starting point as before, by identifying the highest merged-blocks.
 
 ### Added
 * Config: `OneBlockDeletionThreads` to control how many one-block-files will be deleted in parallel on storage, 10 is a sane default, 1 is the minimum.
 * Config: `MaxOneBlockOperationsBatchSize` to control how many files ahead to we read (also how many files we can put in deleting queue at a time.) Should be way more than the number of files that we need to merge in case of forks, 2000 is a sane default, 250 is the minimum
 
+### Removed
+* Option DeleteBlocksBefore is now gone, it is the only behavior (not deleting one-block-files makes no sense for a merger)
+* Option Progressfilename is now gone. BatchMode now has NO Progression option (not needed now that batch should mostly be done from mindreader...)
+
 ### Improved
 * Logging of OneBlockFile deletion now only called once per delete batch
+* When someone else pushes a merged file, merger now detects it and reads the actual blocks to populate its seenblockscache, as discussed here: https://github.com/dfuse-io/merger/issues/1
+* Fixed waiting time to actually use TimeBetweenStoreLookups instead of hardcoded value of 1 second when bundle is incomplete
 
 ## [v0.0.1]
 ### Changed

--- a/merger.go
+++ b/merger.go
@@ -287,6 +287,10 @@ func (m *Merger) processRemoteMergedFile(file io.ReadCloser) (err error) {
 	for _, seenblk := range seenBlocks {
 		m.seenBlocks.Add(seenblk)
 	}
+	if err := m.seenBlocks.Save(); err != nil {
+		zlog.Error("cannot save SeenBlockCache", zap.Error(err))
+	}
+	m.seenBlocks.Truncate()
 
 	return nil
 }

--- a/merger.go
+++ b/merger.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strings"
 	"sync"
@@ -44,7 +45,6 @@ type Merger struct {
 	grpcListenAddr                 string
 	seenBlocks                     *SeenBlockCache
 	progressFilename               string
-	liveMode                       bool
 	minimalBlockNum                uint64
 	stopBlockNum                   uint64
 	writersLeewayDuration          time.Duration // 0 during reprocessing, 25 secs during live.
@@ -62,11 +62,7 @@ func NewMerger(
 	destStore dstore.Store,
 	writersLeewayDuration time.Duration,
 	minimalBlockNum uint64,
-	progressFilename string,
-	deleteBlocksBefore bool,
-	seenCacheFilename string,
 	timeBetweenStoreLookups time.Duration,
-	maxFixableFork uint64,
 	grpcListenAddr string,
 	oneBlockDeletionThreads int,
 	maxOneBlockOperationsBatchSize int,
@@ -74,15 +70,12 @@ func NewMerger(
 	return &Merger{
 		Shutter:                        shutter.New(),
 		sourceStore:                    sourceStore,
-		progressFilename:               progressFilename,
 		destStore:                      destStore,
 		chunkSize:                      100,
 		minimalBlockNum:                minimalBlockNum,
 		writersLeewayDuration:          writersLeewayDuration,
 		bundleLock:                     &sync.Mutex{},
-		deleteBlocksBefore:             deleteBlocksBefore,
 		grpcListenAddr:                 grpcListenAddr,
-		seenBlocks:                     NewSeenBlockCache(seenCacheFilename, maxFixableFork),
 		timeBetweenStoreLookups:        timeBetweenStoreLookups,
 		oneBlockDeletionThreads:        oneBlockDeletionThreads,
 		maxOneBlockOperationsBatchSize: maxOneBlockOperationsBatchSize,
@@ -163,21 +156,6 @@ func (m *Merger) PreMergedBlocks(req *pbmerge.Request, server pbmerge.Merger_Pre
 	return nil
 }
 
-func (m *Merger) SetupBundle(start, stop uint64) {
-	zlog.Info("Setting up bundle", zap.Uint64("start", start), zap.Uint64("stop", stop), zap.Uint64("chunk_size", m.chunkSize))
-	m.liveMode = stop == 0
-	m.bundle = NewBundle(start-(start%m.chunkSize), m.chunkSize)
-	m.stopBlockNum = stop
-
-	if m.CacheInvalid() {
-		m.seenBlocks.Reset()
-	}
-}
-
-func (m *Merger) CacheInvalid() bool {
-	return m.bundle.lowerBlock > m.seenBlocks.HighestSeen+1
-}
-
 func newOneBlockFilesDeleter(store dstore.Store) *oneBlockFilesDeleter {
 	return &oneBlockFilesDeleter{
 		store: store,
@@ -234,7 +212,7 @@ func (od *oneBlockFilesDeleter) processDeletions() {
 
 		var err error
 		for i := 0; i < 3; i++ {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), DeleteObjectTimeout)
 			err = od.store.DeleteObject(ctx, file)
 			cancel()
 			if err == nil {
@@ -248,7 +226,11 @@ func (od *oneBlockFilesDeleter) processDeletions() {
 	}
 }
 
-func (m *Merger) Launch() {
+func (m *Merger) Launch(start, stop uint64, seenCache *SeenBlockCache) {
+	m.bundle = NewBundle(start-(start%m.chunkSize), m.chunkSize)
+	m.stopBlockNum = stop
+	m.seenBlocks = seenCache
+
 	// figure out where to start merging based on dest store
 	zlog.Info("starting merger", zap.Uint64("lower_block_num", m.bundle.lowerBlock))
 
@@ -260,49 +242,83 @@ func (m *Merger) Launch() {
 	m.Shutdown(err)
 }
 
+func fetchMergedFile(store dstore.Store, lowBlockNum uint64) (io.ReadCloser, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), GetObjectTimeout)
+	defer cancel()
+
+	return store.OpenObject(ctx, fileNameForBlocksBundle(lowBlockNum))
+}
+
+func (m *Merger) processRemoteMergedFile(file io.ReadCloser) (err error) {
+	defer file.Close()
+
+	prevLower := m.bundle.lowerBlock
+	newLower := prevLower + m.chunkSize
+	zlog.Info("bumping bundle, destination file already exists",
+		zap.Uint64("previous_lowerblock", prevLower),
+		zap.Uint64("new_lowerblock", newLower),
+	)
+
+	blkReader, err := bstream.GetBlockReaderFactory.New(file)
+	if err != nil {
+		return err
+	}
+
+	seenBlocks := []string{}
+	var lastSeenBlockNum uint64
+	for {
+		block, err := blkReader.Read()
+		if block == nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		seenBlocks = append(seenBlocks, blockFileName(block))
+		lastSeenBlockNum = block.Num()
+	}
+	if lastSeenBlockNum != prevLower+m.chunkSize-1 {
+		return fmt.Errorf("remote merged block file for blocks %d (length:%d) end on block %d", prevLower, m.chunkSize, lastSeenBlockNum)
+	}
+
+	m.bundleLock.Lock()
+	defer m.bundleLock.Unlock()
+	m.bundle = NewBundle(newLower, m.chunkSize)
+	for _, seenblk := range seenBlocks {
+		m.seenBlocks.Add(seenblk)
+	}
+
+	return nil
+}
+
 func (m *Merger) launch() (err error) {
 	var oneBlockFiles []string
 	od := newOneBlockFilesDeleter(m.sourceStore)
 	od.Start(m.oneBlockDeletionThreads, m.maxOneBlockOperationsBatchSize)
 
 	for {
-
 		if m.IsTerminating() {
 			return nil
 		}
 
-		if len(oneBlockFiles) == 0 {
-			zlog.Debug("verifying if bundle file already exist in store")
-			baseBlockNum, err := m.FindNextBaseBlock()
+		zlog.Debug("verifying if bundle file already exist in store")
+		if remoteMergedFile, err := fetchMergedFile(m.destStore, m.bundle.lowerBlock); err == nil {
+			err := m.processRemoteMergedFile(remoteMergedFile)
 			if err != nil {
-				zlog.Warn("an error occured on find next base block", zap.Error(err))
-				select {
-				case <-time.After(m.timeBetweenStoreLookups):
-					continue
-				case <-m.Terminating():
-					return m.Err()
-				}
+				zlog.Error("error processing remote file to bump bundle", zap.Error(err), zap.Uint64("bundle_lowerblock", m.bundle.lowerBlock))
+			} else {
+				continue // keep bumping
 			}
-			if baseBlockNum > m.bundle.lowerBlock {
-				zlog.Info("bumping bundle, destination file already exists",
-					zap.Uint64("previous_lowerblock", m.bundle.lowerBlock),
-					zap.Uint64("new_lowerblock", baseBlockNum),
-				)
-				m.bundleLock.Lock()
-				m.bundle = NewBundle(baseBlockNum, m.chunkSize)
-				if m.CacheInvalid() {
-					m.seenBlocks.Reset()
-				}
-				m.bundleLock.Unlock()
-			}
+		}
 
-			ctx, cancel := context.WithTimeout(context.Background(), ListFilesTimeout)
-			defer cancel()
-
+		if len(oneBlockFiles) == 0 {
 			zlog.Debug("One block file list empty, building list")
 			var tooOldFiles []string
 			var seenFiles []string
+
+			ctx, cancel := context.WithTimeout(context.Background(), ListFilesTimeout)
 			tooOldFiles, seenFiles, oneBlockFiles, err = m.retrieveListOfFiles(ctx)
+			cancel()
 			if err != nil {
 				return err
 			}
@@ -310,14 +326,13 @@ func (m *Merger) launch() (err error) {
 			if m.deleteBlocksBefore {
 				od.Delete(append(tooOldFiles, seenFiles...))
 			}
-		}
-
-		if len(oneBlockFiles) == 0 {
-			select {
-			case <-time.After(m.timeBetweenStoreLookups):
-				continue
-			case <-m.Terminating():
-				return m.Err()
+			if len(oneBlockFiles) == 0 {
+				select {
+				case <-time.After(m.timeBetweenStoreLookups):
+					continue
+				case <-m.Terminating():
+					return m.Err()
+				}
 			}
 		}
 
@@ -340,8 +355,12 @@ func (m *Merger) launch() (err error) {
 		if incompleteBundle {
 			zlog.Info("waiting for more files to complete bundle", zap.Uint64("bundle_lowerblock", m.bundle.lowerBlock), zap.Int("bundle_length", len(m.bundle.fileList)), zap.String("bundle_upper_block_id", m.bundle.upperBlockID))
 			oneBlockFiles = nil
-			time.Sleep(1 * time.Second)
-			continue
+			select {
+			case <-time.After(m.timeBetweenStoreLookups):
+				continue
+			case <-m.Terminating():
+				return m.Err()
+			}
 		}
 
 		zlog.Info("merging bundle",
@@ -354,7 +373,7 @@ func (m *Merger) launch() (err error) {
 			return err
 		}
 		if err := m.seenBlocks.Save(); err != nil {
-			zlog.Error("cannot save SeenBlockCache", zap.String("filename", m.seenBlocks.filename), zap.Error(err))
+			zlog.Error("cannot save SeenBlockCache", zap.Error(err))
 		}
 		m.seenBlocks.Truncate()
 
@@ -367,6 +386,7 @@ func (m *Merger) launch() (err error) {
 		m.bundleLock.Unlock()
 	}
 }
+
 func (m *Merger) retrieveListOfFiles(ctx context.Context) (tooOld []string, seenInCache []string, good []string, err error) {
 	var count int
 
@@ -376,8 +396,6 @@ func (m *Merger) retrieveListOfFiles(ctx context.Context) (tooOld []string, seen
 			return nil
 		}
 		switch {
-		case m.seenBlocks.lowBoundary() == 0 && num < m.bundle.lowerBlock: // edge case: no "seenblock cache"
-			tooOld = append(tooOld, filename)
 		case m.seenBlocks.IsTooOld(num):
 			tooOld = append(tooOld, filename)
 		case m.seenBlocks.SeenBefore(filename):
@@ -402,7 +420,7 @@ func (m *Merger) retrieveListOfFiles(ctx context.Context) (tooOld []string, seen
 	})
 
 	zlog.Info("retrieved list of files",
-		zap.Uint64("seenblock_low_boundary", m.seenBlocks.lowBoundary()),
+		zap.Uint64("seenblock_low_boundary", m.seenBlocks.LowestSeen),
 		zap.Uint64("bundle_lower_block", m.bundle.lowerBlock),
 		zap.Int("seen_files_count", len(seenInCache)),
 		zap.Int("too_old_files_count", len(tooOld)),
@@ -505,4 +523,21 @@ func removeFilesFromArray(in []string, seen map[string]bool) (out []string) {
 		}
 	}
 	return
+}
+
+func blockFileName(block *bstream.Block) string {
+	blockTime := block.Time()
+	blockTimeString := fmt.Sprintf("%s.%01d", blockTime.Format("20060102T150405"), blockTime.Nanosecond()/100000000)
+
+	blockID := block.ID()
+	if len(blockID) > 8 {
+		blockID = blockID[len(blockID)-8:]
+	}
+
+	previousID := block.PreviousID()
+	if len(previousID) > 8 {
+		previousID = previousID[len(previousID)-8:]
+	}
+
+	return fmt.Sprintf("%010d-%s-%s-%s", block.Num(), blockTimeString, blockID, previousID)
 }

--- a/merger_test.go
+++ b/merger_test.go
@@ -98,9 +98,19 @@ func setupMerger(t *testing.T) (m *Merger, src dstore.Store, dst dstore.Store, c
 	dst, err = dstore.NewDBinStore(dstdir)
 	require.NoError(t, err)
 
-	m = NewMerger(src, dst, 0*time.Second, 0, "", false, "/tmp/testmergergob", 0, 999999, "", 2, 100)
+	m = NewMerger(
+		src,
+		dst,
+		0,
+		0,
+		0,
+		"",
+		2,
+		100,
+	)
 	m.chunkSize = 5
 	m.bundle = NewBundle(100, 100)
+	m.seenBlocks = NewSeenBlockCacheInMemory(100, 0)
 
 	return m, src, dst, func() {
 		os.RemoveAll(srcdir)

--- a/merger_test.go
+++ b/merger_test.go
@@ -102,15 +102,15 @@ func setupMerger(t *testing.T) (m *Merger, src dstore.Store, dst dstore.Store, c
 		src,
 		dst,
 		0,
+		5,
+		NewSeenBlockCacheInMemory(100, 0),
+		100,
 		0,
 		0,
 		"",
 		2,
 		100,
 	)
-	m.chunkSize = 5
-	m.bundle = NewBundle(100, 100)
-	m.seenBlocks = NewSeenBlockCacheInMemory(100, 0)
 
 	return m, src, dst, func() {
 		os.RemoveAll(srcdir)

--- a/storage_test.go
+++ b/storage_test.go
@@ -157,8 +157,7 @@ func TestFindNextBaseBlock(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			m := &Merger{destStore: s, chunkSize: test.chunkSize, minimalBlockNum: test.minimalBlockNum}
-			i, err := m.FindNextBaseBlock()
+			i, err := FindNextBaseBlock(s, test.minimalBlockNum, test.chunkSize)
 			require.NoError(t, err)
 
 			assert.Equal(t, int(test.expectedBaseBlock), int(i))


### PR DESCRIPTION
* fix seen-blocks cache populating when we fetch a merged-blocks-file from another location. See CHANGELOG.md for more changes in options and behavior

* adresses https://github.com/dfuse-io/merger/issues/1