### PR TITLE
Add guard for lastMergedBlockTime

### DIFF
--- a/merger.go
+++ b/merger.go
@@ -141,7 +141,13 @@ func (m *Merger) launch() (err error) {
 
 		m.bundler.Commit(highestBundleBlockNum)
 
-		zlog.Info("bundle merged and committed", zap.Stringer("bundle", m.bundler), zap.Time("last_merge_one_block_time", m.bundler.LastMergeOneBlockFile().BlockTime))
+		lastMergedOneBlockFile := m.bundler.LastMergeOneBlockFile()
+		var lastMergedBlockTime time.Time
+		if lastMergedOneBlockFile != nil {
+			lastMergedBlockTime = lastMergedOneBlockFile.BlockTime
+		}
+
+		zlog.Info("bundle merged and committed", zap.Stringer("bundle", m.bundler), zap.Time("last_merge_one_block_time", lastMergedBlockTime))
 
 		state := &State{ExclusiveHighestBlockLimit: m.bundler.ExclusiveHighestBlockLimit()}
 		zlog.Info("saving state", zap.Stringer("state", state))


### PR DESCRIPTION
fixes

```
Starting dfuse for Ethereum with config file '$HOME/firehose_near.yaml'
Launching applications: firehose,merger,mindreader-node,relayer
--home=$datadir/mindreader/data  run
failed to load bundle  (merger/app.go:88){"file_name": "$datadir/merger/merger.seen.gob"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xffab14]
goroutine 213 [running]:
github.com/streamingfast/merger.(*Merger).launch(0xc0007ca000)
        $HOME/go/pkg/mod/github.com/streamingfast/merger@v0.0.3-0.20211222185803-be94ba68b3dd/merger.go:144 +0x494
github.com/streamingfast/merger.(*Merger).Launch(0xc0007ca000)
        $HOME/go/pkg/mod/github.com/streamingfast/merger@v0.0.3-0.20211222185803-be94ba68b3dd/merger.go:77 +0x12a
created by github.com/streamingfast/merger/app/merger.(*App).Run
        $HOME/go/pkg/mod/github.com/streamingfast/merger@v0.0.3-0.20211222185803-be94ba68b3dd/app/merger/app.go:142
```